### PR TITLE
docs: Next.js 동적 라우팅 실습 추가

### DIFF
--- a/section02/src/pages/404.tsx
+++ b/section02/src/pages/404.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>존재하지 않는 페이지입니다.</div>;
+}

--- a/section02/src/pages/book/[[...id]].tsx
+++ b/section02/src/pages/book/[[...id]].tsx
@@ -1,0 +1,27 @@
+import { useRouter } from "next/router";
+
+export default function Page() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  console.log(id);
+
+  return <h1>Book {id}</h1>;
+}
+
+/* 
+이러한 가변적인 값들을 URL 파라미터라고 부르는데요 이렇게 URL 파라미터를 사용하는 동적 경로를 갖는 페이지를 생성하려면
+먼저 book이라는 경로에 맞춰서 book폴더를 만들어 주신 다음에 해당 폴더 안에 [id].tsx 라는 이름으로 파일을 만들어 주시면 됩니다
+우리 Next.js가 이 대괄호가 포함된 파일명을 보고
+이 파일은 지금 슬래시 북에 슬래시 아이디라는 가변적인 값 즉 URL 파라미터를 갖는 동적 경로에 대응하는 그런 파일이구나
+라고 인식을 해서 이 경로상의 아이디가 뭐 1번 값으로 들어오던 2번 값으로 들어오던 그게
+아니면 뭐 100번 값으로 들어오던 즉 URL 파라미터의 값이 뭐가 되던 이 파일에 작성된
+컴포넌트를 페이지로써 화면에 렌더링 시키도록 설정이 됩니다
+*/
+
+// ...id.tsx -> id 앞에 ...이 붙으면 여러 개의 파라미터를 배열 형태로 받을 수 있음
+// catch all segments (모든 세그먼트를 잡아낸다)라고 부름
+
+// index경로로 오면 404에러
+// [[...id]].tsx로 바꾸면 index경로도 허용됨
+// optional catch all segments (선택적인 모든 세그먼트를 잡아낸다)라고 부름

--- a/section02/src/pages/search.tsx
+++ b/section02/src/pages/search.tsx
@@ -1,3 +1,0 @@
-export default function Search() {
-  return <h1>Search</h1>;
-}

--- a/section02/src/pages/search/index.tsx
+++ b/section02/src/pages/search/index.tsx
@@ -1,3 +1,13 @@
+import { useRouter } from "next/router";
+
 export default function Search() {
-  return <h1>Search</h1>;
+  const router = useRouter(); // 변수 안에 router객체 저장
+  console.log(router); // router객체 확인
+  //   const q = router.query.q; // 쿼리스트링 중 q에 해당하는 값 추출
+  const { q } = router.query; // 비구조화 할당 문법으로 쿼리스트링 중 q에 해당하는 값 추출
+  return <h1>Search {q}</h1>;
 }
+
+// 쿼리스트링을 쓴다고 해서 폴더 구조를 변경하거나 파일명을 변경하지 않음
+// 쿼리스트링은 주소창에서 직접 입력하거나 링크로 이동할 때 사용
+// 쿼리스트링을 사용하는 페이지는 일반적인 페이지와 동일하게 취급


### PR DESCRIPTION
📝 작업 개요

- Next.js 동적 라우팅 관련 실습 
- URL 파라미터, catch-all, optional catch-all 경로 설정 방법

---

✅ 작업 내용

- /book/[id].tsx: URL 파라미터 기반 동적 라우팅 실습
- /book/[...id].tsx: catch-all segments 실습
- /book/[[...id]].tsx: optional catch-all segments 실습
- index 경로 진입 시 동작 차이 (404 vs optional 허용)

---

📸 스크린샷
<img width="231" height="342" alt="image" src="https://github.com/user-attachments/assets/129448fe-0fbe-4885-8e9a-2c384922192d" />

---

🔍 체크리스트
- [ ] 각 라우팅 페이지가 정상적으로 렌더링 되는지 확인
- [ ] 주석 설명이 실습 내용을 잘 반영하는지 확인
