### PR TITLE
feat(app): 전역 헤더 내비게이션 및 useRouter 기반 페이지 전환 추가

### DIFF
--- a/section02/src/pages/_app.tsx
+++ b/section02/src/pages/_app.tsx
@@ -1,13 +1,33 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+import Link from "next/link";
+import { useRouter } from "next/router";
 
 export default function App({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+  const onClickButton = () => {
+    router.push("/test");
+    // router.replace("/test");
+    // router.back();
+  };
   return (
     <>
-      <header>글로벌 헤더</header>
+      <header>
+        <Link href="/">index</Link>
+        &nbsp;
+        <Link href="/search">search</Link>
+        &nbsp;
+        <Link href="/book/1">book/1</Link>
+        <div>
+          <button onClick={onClickButton}>/test 페이지로 이동</button>
+        </div>
+      </header>
       <Component {...pageProps} />
     </>
   );
 }
 // 모든 페이지 역할을 하는 컴포넌트의 부모 컴포넌트
 // 전체 페이지에 공통적으로 들어가는 레이아웃이나 상태 관리 등을 처리
+// a태그는 매번 서버에서 새로고침이 일어나서 속도가 느리다
+// 지금 클라이언트 사이드 렌더링 방식으로 페이지 전환 -> 굿
+// 함수 내부에서도 페이지를 클라이언트 사이드 렌더링 방식으로 이동 가능


### PR DESCRIPTION
📝 작업 개요

- Next.js Pages Router 환경에서 전역 헤더 내비게이션과 programmatic routing(useRouter)을 실습

---

✅ 작업 내용

- pages/_app.tsx
- 상단 header에 index / search / book/1 링크 추가 (클라이언트 사이드 라우팅)
- /test로 이동하는 버튼 추가 및 router.push 핸들러 구현
- CSR 전환 관련 주석 정리(push/replace/back 비교 가능하도록 구조 마련)

---

🔍 체크리스트

 - [ ] 상단 링크로 페이지 전환 시 전체 새로고침 없이 이동되는지 확인
 - [ ]  “/test 페이지로 이동” 버튼 클릭 시 /test로 정상 이동되는지 확인
 - [ ] 필요 시 router.replace로 히스토리 스택 미잔존 이동 동작도 확인